### PR TITLE
Updated to include registry key tweak

### DIFF
--- a/10_2_Uncheck User Must Enter Name And Password.ps1
+++ b/10_2_Uncheck User Must Enter Name And Password.ps1
@@ -1,2 +1,9 @@
 ﻿# just uncheck the checkbox in the app that opens.
 netplwiz
+
+#Windows v2004 ( and later ) First modify registry key to allow the checkbox to be visible:
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\PasswordLess\Device]
+
+Change registry key "DevicePasswordLessBuildVersion" to  0 {as 32Bit DWORD} [ default is 2 ]
+
+"DevicePasswordLessBuildVersion"=dword:00000000


### PR DESCRIPTION
On Windows v2004, by default the netplwiz checkbox isn't visible, and a registry key change is necessary to be able to access the checkbox